### PR TITLE
Ask for updates at start to fix update gap

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ instance.prototype.init_osc = function() {
 			self.sendOSC("/xinfo",[]);
 			self.sendOSC('/-snap/name',[]);
 			self.sendOSC('/-snap/index',[]);
+			self.pulse();
 			self.heartbeat = setInterval( function () { self.pulse(); },9500);
 		});
 
@@ -561,7 +562,6 @@ instance.prototype.init_actions = function(system) {
 				}
 			]
 		},
-
 
 		'load_snap':     {
 			label:     'Load Console Snapshot',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"xair"
 	],
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Audio"


### PR DESCRIPTION
The module was not getting updates from the mixer until after the first interval.
This sends an initial request, then starts the interval