### PR TITLE
Adds relative loudness % feedback

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -61,20 +61,28 @@ Variable | Description
 **$(INSTANCENAME:l_fxsend#)** | Label on FX Bus Master #
 **$(INSTANCENAME:f_lr_d)** | LR/Main Fader dB
 **$(INSTANCENAME:f_lr_p)** | LR/Main Fader Percent
+**$(INSTANCENAME:f_lr_rp)** | LR/Main Relative Loudness Percent
 **$(INSTANCENAME:f_rtn_aux_d)** | USB/Aux return Fader dB
 **$(INSTANCENAME:f_rtn_aux_p)** | USB/Aux return Fader Percent
+**$(INSTANCENAME:f_rtn_aux_rp)** | USB/Aux return Fader Relative Loudness Percent
 **$(INSTANCENAME:f_ch#_d)** | Channel # Fader dB
 **$(INSTANCENAME:f_ch#_p)** | Channel # Fader Percent
+**$(INSTANCENAME:f_ch#_rp)** | Channel # Fader Relative Loudness Percent
 **$(INSTANCENAME:f_bus#_d)** | Bus Master # Fader dB
 **$(INSTANCENAME:f_bus#_p)** | Bus Master # Fader Percent
+**$(INSTANCENAME:f_bus#_rp)** | Bus Master # Fader Relative Loudness Percent
 **$(INSTANCENAME:f_dca#_d)** | DCA # Fader dB
 **$(INSTANCENAME:f_dca#_p)** | DCA # Fader Percent
+**$(INSTANCENAME:f_dca#_rp)** | DCA # Fader Relative Loudness Percent
 **$(INSTANCENAME:f_rtn#_d)** | Return # Fader dB
 **$(INSTANCENAME:f_rtn#_p)** | Return # Fader Percent
+**$(INSTANCENAME:f_rtn#_rp)** | Return # Fader Relative Loudness Percent
 **$(INSTANCENAME:f_fxsend#_d)** | FX Bus Master # Fader dB
 **$(INSTANCENAME:f_fxsend#_p)** | FX Bus Master # Fader Percent
+**$(INSTANCENAME:f_fxsend#_rp)** | FX Bus Master # Fader Relative Loudness Percent
 **$(INSTANCENAME:f_solo_d)** | Solo (monitor) output level dB
 **$(INSTANCENAME:f_solo_p)** | Solo (monitor) output level Percent
+**$(INSTANCENAME:f_fxsend#_rp)** | FX Bus Master # Fader Relative Loudness Percent
 
 **Note *Snapshot numbers*:** Replace {num} with the desired 2-digit snapshot number: $(xair:s_name_04). A snapshot with no name will have a default name of '#{num}': #04 (it is probably empty).
 

--- a/HELP.md
+++ b/HELP.md
@@ -61,7 +61,7 @@ Variable | Description
 **$(INSTANCENAME:l_fxsend#)** | Label on FX Bus Master #
 **$(INSTANCENAME:f_lr_d)** | LR/Main Fader dB
 **$(INSTANCENAME:f_lr_p)** | LR/Main Fader Percent
-**$(INSTANCENAME:f_lr_rp)** | LR/Main Relative Loudness Percent
+**$(INSTANCENAME:f_lr_rp)** | LR/Main Relative Loudness Percent **see notes*
 **$(INSTANCENAME:f_rtn_aux_d)** | USB/Aux return Fader dB
 **$(INSTANCENAME:f_rtn_aux_p)** | USB/Aux return Fader Percent
 **$(INSTANCENAME:f_rtn_aux_rp)** | USB/Aux return Fader Relative Loudness Percent
@@ -85,6 +85,17 @@ Variable | Description
 **$(INSTANCENAME:f_fxsend#_rp)** | FX Bus Master # Fader Relative Loudness Percent
 
 **Note *Snapshot numbers*:** Replace {num} with the desired 2-digit snapshot number: $(xair:s_name_04). A snapshot with no name will have a default name of '#{num}': #04 (it is probably empty).
+
+**Note *Relative Loudness*:** This variable shows the percieved loudness with 0dB fader gain as a reference (100%). +/- 10dB changes become x2/x0.5 respectively as per the Loudness Equation (10 x log2). This allows for a more non-savy user friendly readout. *See table bellow.*
+#####Example values :
+d (dB) | % (_p)| % (_rp)
+-----------------|---------------|---------------
++10 | 100 | 200
+0 | 75 | 100
+-10 | 50 | 50
+-20 | 38 | 25
+-30 | 25 | 13
+-40 | 19 | 6
 
 
 ## Feedback

--- a/defOuts.json
+++ b/defOuts.json
@@ -1,0 +1,72 @@
+[
+    {
+        "id": "main",
+        "digits": 1,
+        "min": 1,
+        "max": 2,
+        "srcAmt": 10,
+        "description": "Main/Phones Outs",
+        "hasPos": false,
+        "srcs": [
+            "LR",
+            "Mon",
+            "UOut"
+        ]
+    },
+    {
+        "id": "aux",
+        "digits": 1,
+        "min": 1,
+        "max": 6,
+        "srcAmt": 55,
+        "description": "Aux Outs",
+        "hasPos": true,
+        "srcs": [
+            "Ch",
+            "Aux",
+            "FxRtn",
+            "Bus",
+            "FxSnd",
+            "L",
+            "R",
+            "UOut"
+        ]
+    },
+    {
+        "id": "p16",
+        "digits": 2,
+        "min": 1,
+        "max": 16,
+        "srcAmt": 55,
+        "description": "P16 Outs",
+        "hasPos": true,
+        "srcs": [
+            "Ch",
+            "Aux",
+            "FxRtn",
+            "Bus",
+            "FxSnd",
+            "L",
+            "R",
+            "UOut"
+        ]
+    },
+    {
+        "id": "usb",
+        "digits": 2,
+        "min": 1,
+        "max": 16,
+        "srcAmt": 37,
+        "description": "USB sends Outs",
+        "hasPos": true,
+        "srcs": [
+            "Ch",
+            "Aux",
+            "FxRtn",
+            "Bus",
+            "FxSnd",
+            "L",
+            "R"
+        ]
+    }
+]

--- a/index.js
+++ b/index.js
@@ -518,7 +518,7 @@ instance.prototype.init_solos = function () {
 					});
 					soloVariables.push({
 						label: fbDescription + " % Relative Loudness",
-						name: soloID + "_pp"
+						name: soloID + "_rp"
 					});
 				} else {
 					soloActions[actID] = {
@@ -1398,7 +1398,7 @@ instance.prototype.init_strips = function () {
 			});
 			defVariables.push({
 				label: theStrip.description + " % Relative Loudness",
-				name: fID + "_pp"
+				name: fID + "_rp"
 			});
 			if ('' != labelSfx) {
 				theID = chID + labelSfx + "/name";
@@ -1451,7 +1451,7 @@ instance.prototype.init_strips = function () {
 					});
 					defVariables.push({
 						label: capFirst(fbID) + " " + c + sendID + " % Relative Loudness",
-						name: fID + "_pp"
+						name: fID + "_rp"
 					});
 				}
 			}
@@ -1503,7 +1503,7 @@ instance.prototype.init_strips = function () {
 					});
 					defVariables.push({
 						label: theStrip.description + " " + c + " % Relative Loudness",
-						name: fID + "_pp"
+						name: fID + "_rp"
 					});
 					if (theStrip.hasLevel) {
 						for (b = 1; b<11; b++) {
@@ -1531,7 +1531,7 @@ instance.prototype.init_strips = function () {
 							});
 							defVariables.push({
 								label: capFirst(fbID) + " " + c + sendID + " % Relative Loudness",
-								name: fID + "_pp"
+								name: fID + "_rp"
 							});
 							
 						}
@@ -1760,10 +1760,10 @@ instance.prototype.stepsToFader = function (i, steps) {
 	return Math.floor(res * 10000) / 10000;
 };
 
-instance.prototype.faderToDB = function ( f, steps , pp) {
+instance.prototype.faderToDB = function ( f, steps , rp) {
 // “f” represents OSC float data. f: [0.0, 1.0]
 // “d” represents the dB float data. d:[-oo, +10]
-// if "pp" (perceptual percent) is true, the function returns a loudness perceptual (base 10/33.22) change in % compared to unity (0dB)
+// if "rp" (Relative percent) is true, the function returns a loudness perceptual (base 10/33.22) change in % compared to unity (0dB)
 	var d = 0;
 
 	if (f >= 0.5) {
@@ -1775,7 +1775,7 @@ instance.prototype.faderToDB = function ( f, steps , pp) {
 	} else if (f >= 0.0) {
 		d = f * 480.0 - 90.0;		// min dB value: -90 or -oo
 	}
-	return (f==0 ? (pp ? "0":"-oo") : (pp? "":d>0 ? '+':'') + (pp? (100 * 10 ** (d/33.22)) : Math.round(d * 1023.5) / 1024).toFixed(1));
+	return (f==0 ? (rp ? "0":"-oo") : (rp? "":d>0 ? '+':'') + (rp? (100 * 10 ** (d/33.22)) : Math.round(d * 1023.5) / 1024).toFixed(1));
 };
 
 instance.prototype.init_osc = function() {
@@ -1822,7 +1822,7 @@ instance.prototype.init_osc = function() {
 					self.xStat[node][leaf] = v;
 					self.setVariable(self.xStat[node].varID + '_p',Math.round(v * 100));
 					self.setVariable(self.xStat[node].varID + '_d',self.faderToDB(v,1024,false));
-					self.setVariable(self.xStat[node].varID + '_pp',Math.round(self.faderToDB(v,1024,true)));
+					self.setVariable(self.xStat[node].varID + '_rp',Math.round(self.faderToDB(v,1024,true)));
 					self.xStat[node].idx = self.fLevels[self.xStat[node].fSteps].findIndex((i) => i >= v);
 					break;
 				case 'name':


### PR DESCRIPTION
Adding relative loudness % feedback based on unity gain, for a less confusing reading for the general public.

Like a lot of consumer oriented software, this approach puts 100% at 0dB and gives +/-10dB a 200% perceptual change in volume instead of ~300% actual volume change as per [sengpielaudio](http://www.sengpielaudio.com/calculator-levelchange.htm).

Unity gain being at 100% helps to keep the gain staging less confusing in the console, with +10dB (fader max) being 200%.

As this has be requested by a lot of my clients (that are not audio savy) I thought I'd add the option