### PR TITLE
Bugfix: prevent variable overwrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -640,9 +640,10 @@ instance.prototype.init_solos = function () {
 	}
 	self.soloOffset = soloOffset;
 	Object.assign(self.xStat, stat);
-	Object.assign(self.variableDefs, soloVariables);
 	Object.assign(self.actionDefs, soloActions);
 	Object.assign(self.muteFeedbacks, soloFeedbacks);
+	self.variableDefs.push(...soloVariables);
+
 };
 
 instance.prototype.init_strips = function () {
@@ -1700,12 +1701,9 @@ instance.prototype.init_strips = function () {
 		}
 	}
 	self.xStat = stat;
-	self.variableDefs = defVariables;
 	self.actionDefs = fadeActions;
-	Object.assign(self.actionDefs, sendActions);
-	Object.assign(self.actionDefs, muteActions);
-	Object.assign(self.actionDefs, procActions);
-	Object.assign(self.actionDefs, storeActions);
+	Object.assign(self.actionDefs, sendActions, muteActions, procActions, storeActions);
+	self.variableDefs.push(...defVariables);
 	self.muteFeedbacks = muteFeedbacks;
 	self.colorFeedbacks = colorFeedbacks;
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"xair"
 	],
-	"version": "1.6.11",
+	"version": "1.6.12",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Audio",


### PR DESCRIPTION
When assembling the internal list of variable definitions, an incorrect function was used. Instead of extending the array, the new items overwrote the first few definitions.
This resulted in some documented variables not being created properly.
