### PR TITLE
Collect list of XAir units on network

### DIFF
--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -382,11 +382,8 @@ export function buildStripDefs(self) {
 						],
 						callback: async (action, context) => {
 							const opt = action.options
-							let nVal = opt.num
-							if (opt.type == '/ch/') {
-								nVal = pad0(nVal)
-							}
-							const cmd = opt.type + nVal
+							let nVal = (opt.type == '/ch/' ? pad0(opt.num) : opt.num)
+							let cmd = opt.type + nVal
 							cmd += opt.type == '/dca/' ? '/fader' : '/mix/fader'
 							let fVal = fadeTo(action.actionId, cmd, opt, self)
 							const arg = {

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -1,3 +1,4 @@
+'use strict'
 import { defStrip } from './defStrip.js'
 import { combineRgb, Regex } from '@companion-module/base'
 import { pad0, unSlash, setToggle, fadeTo } from './helpers.js'
@@ -153,7 +154,7 @@ export function buildStripDefs(self) {
 							const opt = action.options
 							const nVal = opt.type == '/ch/' ? pad0(opt.num) : opt.num
 							const cmd =
-								action.actionId == 'lr' ? opt.type + nVal + '/mix/lr' : opt.type + nval + '/' + action.actionId + '/on'
+								action.actionId == 'lr' ? opt.type + nVal + '/mix/lr' : opt.type + nVal + '/' + action.actionId + '/on'
 							const arg = {
 								type: 'i',
 								value: setToggle(self.xStat[cmd].isOn, opt.set),
@@ -425,7 +426,7 @@ export function buildStripDefs(self) {
 							if (opt.type == '/ch/') {
 								nVal = pad0(nVal)
 							}
-							const strip = opt.type + nVal
+							let strip = opt.type + nVal
 							strip += opt.type == '/dca/' ? '/fader' : '/mix/fader'
 							fadeTo(action.actionId, strip, opt, self)
 						},
@@ -463,7 +464,7 @@ export function buildStripDefs(self) {
 							if (opt.type == '/ch/') {
 								nVal = pad0(nVal)
 							}
-							const strip = opt.type + nVal
+							let strip = opt.type + nVal
 							strip += opt.type == '/dca/' ? '/fader' : '/mix/fader'
 							let fVal = fadeTo(action.actionId, strip, opt, self)
 							const arg = {
@@ -526,8 +527,8 @@ export function buildStripDefs(self) {
 
 				fadeActions[fadeID + '_a'].options.push({
 					type: 'number',
-					tooltip: 'Move fader +/- percent.\nFader Percent:\n0 = -oo, 75 = 0db, 100 = +10db',
-					label: 'Adjust',
+					tooltip: 'Move fader +/- percent.',
+					label: 'Adjust By',
 					id: 'ticks',
 					min: -100,
 					max: 100,
@@ -671,9 +672,8 @@ export function buildStripDefs(self) {
 							nVal = parseInt(opt.chNum) + '/'
 						}
 						const bVal = pad0(opt.busNum)
-						const strip = opt.type + nval + 'mix/' + bVal + '/level'
-						let fVal = fadeTo(action.actionId, strip, opt, self)
-						self.sendOSC(strip, { type: 'f', value: fVal })
+						const strip = opt.type + nVal + 'mix/' + bVal + '/level'
+						fadeTo(action.actionId, strip, opt, self)
 					},
 				}
 
@@ -711,8 +711,8 @@ export function buildStripDefs(self) {
 						},
 						{
 							type: 'number',
-							title: 'Move fader +/- percent.\nFader percent:\n0 = -oo, 75 = 0db, 100 = +10db',
-							label: 'Adjust',
+							title: 'Move fader +/- percent.',
+							label: 'Adjust by',
 							id: 'ticks',
 							min: -100,
 							max: 100,
@@ -728,7 +728,7 @@ export function buildStripDefs(self) {
 							nVal = parseInt(opt.chNum) + '/'
 						}
 						const bVal = pad0(opt.busNum)
-						const strip = opt.type + nval + 'mix/' + bVal + '/level'
+						let strip = opt.type + nVal + 'mix/' + bVal + '/level'
 						let fVal = fadeTo(action.actionId, strip, opt, self)
 						self.sendOSC(strip, { type: 'f', value: fVal })
 					},
@@ -747,7 +747,7 @@ export function buildStripDefs(self) {
 				}
 
 				storeActions[sendID + '_s'] = {
-					label: 'Store Send Level',
+					name: 'Store Send Level',
 					options: [
 						{
 							type: 'dropdown',
@@ -787,7 +787,7 @@ export function buildStripDefs(self) {
 							choices: [
 								{
 									id: 'me',
-									label: 'Channel',
+									label: 'Channel Send',
 								},
 								...self.STORE_LOCATION,
 							],
@@ -802,13 +802,13 @@ export function buildStripDefs(self) {
 							nVal = parseInt(opt.chNum) + '/'
 						}
 						const bVal = pad0(opt.busNum)
-						const strip = opt.type + nval + 'mix/' + bVal + '/level'
+						const strip = opt.type + nVal + 'mix/' + bVal + '/level'
 						fadeTo(action.actionId, strip, opt, self)
 					},
 				}
 
 				storeActions[sendID + '_r'] = {
-					label: 'Recall Send Level',
+					name: 'Recall Send Level',
 					options: [
 						{
 							type: 'dropdown',
@@ -848,7 +848,7 @@ export function buildStripDefs(self) {
 							choices: [
 								{
 									id: 'me',
-									label: 'Channel',
+									label: 'Channel Send',
 								},
 								...self.STORE_LOCATION,
 							],
@@ -863,7 +863,7 @@ export function buildStripDefs(self) {
 							nVal = parseInt(opt.chNum) + '/'
 						}
 						const bVal = pad0(opt.busNum)
-						const strip = opt.type + nval + 'mix/' + bVal + '/level'
+						const strip = opt.type + nVal + 'mix/' + bVal + '/level'
 						let fVal = fadeTo(action.actionId, strip, opt, self)
 						self.sendOSC(strip, { type: 'f', value: fVal })
 					},

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -8,6 +8,7 @@ export function buildStripDefs(self) {
 	let stat = {}
 	let muteActions = {}
 	let procActions = {}
+	let trimActions = {}
 	let fadeActions = {}
 	let storeActions = {}
 	let sendActions = {}
@@ -70,8 +71,6 @@ export function buildStripDefs(self) {
 		if (defaultLabel != '' && d > 0) {
 			defaultLabel = defaultLabel + ' '
 		}
-
-		// console.log(`${chID}${muteSfx}, ${fadeSfx}`);
 
 		// additional strip toggles
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -7,6 +7,12 @@ to get additional information about the consoles and their capabilities.
 ## Configuration
 **Target IP:** Enter the IP address of the Mixer
 
+**Scan for XAir Mixers?** Module will scan for XAir mixers on the network
+
+**Select mixer by Name** Choose a mixer from those located on the network
+
+**Note* Once a mixer (name) is chosen, the module will attempt to re-locate it if the IP changes. This feature can be disabled by un-checking the *Scan for Mixers* option
+
 ## Supported Actions
 Console Function | What it does
 -----------------|---------------
@@ -53,6 +59,8 @@ Variable | Description
 **$(INSTANCENAME:m_fw)** | Mixer Firmware
 **$(INSTANCENAME:s_name)** | Current Snapshot Name
 **$(INSTANCENAME:s_index)** | Current Snapshot Number
+**$(INSTANCENAME:s_name_n)** | Next Snapshot Name
+**$(INSTANCENAME:s_name_p)** | Prior Snapshot Name
 **$(INSTANCENAME:s_name_{num})** | Name of Snapshot {num} **see notes*
 **$(INSTANCENAME:l_lr)** | Label on LR/Main
 **$(INSTANCENAME:l_rtn_aux)** | Label on USB/Aux return

--- a/defStrip.js
+++ b/defStrip.js
@@ -10,9 +10,11 @@ export const defStrip = [
 		'fadeID': 'fad',
 		'hasLevel': true,
 		'hasMix': true,
+		'trim': ['preamp','headamp'],
 		'proc': ['gate', 'insert', 'eq', 'dyn', 'lr'],
 		'procPfx': '',
 		'hasOn': true,
+		'hasPan': true,
 	},
 	{
 		'id': 'rtn',
@@ -25,9 +27,11 @@ export const defStrip = [
 		'fadeID': 'fad',
 		'hasLevel': true,
 		'hasMix': true,
+		'trim': ['preamp'],
 		'proc': ['eq', 'lr'],
 		'procPfx': '',
 		'hasOn': true,
+		'hasPan': false,
 	},
 	{
 		'id': 'fxsend',
@@ -43,6 +47,7 @@ export const defStrip = [
 		'proc': [],
 		'procPfx': '',
 		'hasOn': true,
+		'hasPan': false,
 	},
 	{
 		'id': 'bus',
@@ -58,6 +63,7 @@ export const defStrip = [
 		'proc': ['insert', 'eq', 'dyn', 'lr'],
 		'procPfx': '',
 		'hasOn': true,
+		'hasPan': true,
 	},
 	{
 		'id': 'dca',
@@ -72,6 +78,7 @@ export const defStrip = [
 		'hasMix': false,
 		'proc': [],
 		'hasOn': true,
+		'hasPan': false,
 	},
 	{
 		'id': 'lr',
@@ -87,6 +94,7 @@ export const defStrip = [
 		'procPfx': 'm_',
 		'proc': ['insert', 'eq', 'dyn'],
 		'hasOn': true,
+		'hasPan': true,
 	},
 	{
 		'id': 'rtn/aux',
@@ -99,9 +107,11 @@ export const defStrip = [
 		'fadeID': 'usbFad',
 		'hasLevel': true,
 		'hasMix': true,
+		'trim': ['preamp','headamp'],
 		'proc': ['eq'],
 		'procPfx': 'u_',
 		'hasOn': true,
+		'hasPan': true,
 	},
 	{
 		'id': 'config/mute',
@@ -114,5 +124,6 @@ export const defStrip = [
 		'hasMix': false,
 		'proc': [],
 		'hasOn': false,
+		'hasPan': false,
 	},
 ]

--- a/index.js
+++ b/index.js
@@ -44,10 +44,6 @@ class BAirInstance extends InstanceBase {
 		this.fLevels[161] = []
 		this.blinkingFB = {}
 		this.crossFades = {}
-		this.PollCount = 100
-		this.PollTimeout = 100
-		this.needStats = true
-		this.blinkOn = false
 
 		buildConstants(this)
 	}
@@ -57,6 +53,10 @@ class BAirInstance extends InstanceBase {
 
 		// cross-fade steps per second
 		this.fadeResolution = 20
+		this.PollCount = 100
+		this.PollTimeout = 100
+		this.needStats = true
+		this.blinkOn = false
 
 		buildStripDefs(this)
 		buildSoloDefs(this)

--- a/index.js
+++ b/index.js
@@ -30,6 +30,14 @@ class BAirInstance extends InstanceBase {
 		this.blinkingFB = {}
 		this.crossFades = {}
 
+		if (process.env.DEVELOPER) {
+			this.PollCount = 125
+			this.PollTimeout = 100
+		} else {
+			this.PollCount = 30
+			this.PollTimeout = 25
+		}
+
 		buildConstants(this)
 	}
 
@@ -55,8 +63,6 @@ class BAirInstance extends InstanceBase {
 
 		// cross-fade steps per second
 		this.fadeResolution = 20
-		this.PollCount = 30
-		this.PollTimeout = 25
 		this.needStats = true
 		this.hostResponse = false
 		this.blinkOn = false

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ class BAirInstance extends InstanceBase {
 		this.fLevels[161] = []
 		this.blinkingFB = {}
 		this.crossFades = {}
-		this.PollCount = 60
-		this.PollTimeout = 500
+		this.PollCount = 100
+		this.PollTimeout = 100
 		this.needStats = true
 		this.blinkOn = false
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "behringer-xair",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"type": "module",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Scans for list of mixers on network.
Creates a drop-down list for config options.
If sync times-out with no response, automatically re-configure the IP address if mixer with same name is located.
Should enable equivalent of issue #43 