### PR TITLE
Functional Implementation of the 0dB fader limit

### DIFF
--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -535,6 +535,14 @@ export function buildStripDefs(self) {
 					default: 1,
 				})
 
+				fadeActions[fadeID + '_a'].options.push({
+					type: 'checkbox',
+					tooltip: 'Limit fader adjustment to 0dBfs maximum, if the adjustment were to go above 0dB, it will go back to 0dB',
+					label: 'Limit to 0dB maximum',
+					id: 'faderLim',
+					default: 0,
+				})
+
 				for (var sfx of ['', '_a']) {
 					fadeActions[fadeID + sfx].options.push({
 						type: 'number',

--- a/helpers.js
+++ b/helpers.js
@@ -22,6 +22,7 @@ export function fadeTo(cmd, strip, opt, self) {
 
 
 	const opTicks = parseInt(opt.ticks)
+	const faderLim = opt.faderLim
 	const steps = stat.fSteps
 	const span = parseFloat(opt.duration)
 	const oldVal = stat[node]
@@ -67,6 +68,11 @@ export function fadeTo(cmd, strip, opt, self) {
 			r = oldVal + xDelta
 		}
 	}
+
+	// If fader is at more than 0dB, or 0,75f, revert to 0,75, dependant on the "Limit faders to 0dB Max" checkbox in the module settings
+	/* if (faderLim) r = Math.min(r, 0.75); */
+
 	// self.log('debug',`---------- ${oldIdx}:${oldVal} by ${byVal}(${opTicks}) fadeTo ${newIdx}:${r} ----------`);
+
 	return r
 }


### PR DESCRIPTION
As asked in [this issue](https://github.com/bitfocus/companion-module-behringer-xair/issues/71), I tried to implement a 0dB limit for the faders, and instead of a global setting, I chose to make it per button, which I think is smarter and less messy code wise

Here's the first commit
- Adding a "Limit to 0dB maximum" checkbox in the fader adjust button settings
- Grabbing the bool value of said checkbox (faderLim) to condition a limit to 0.75f on the fader (0dB)

I placed the condition at the very end of the FadeTo function, this might have some unintended effect on the fading, or maybe not and it was the right wall, haven't tested yet