### PR TITLE
Functional Implementation of the 0dB fader limit

### DIFF
--- a/buildSoloDefs.js
+++ b/buildSoloDefs.js
@@ -1,5 +1,5 @@
 import { combineRgb, InstanceStatus } from '@companion-module/base'
-import { pad0, unSlash, setToggle } from './helpers.js'
+import { pad0, unSlash, setToggle, fadeTo } from './helpers.js'
 import { ICON_SOLO } from './icons.js'
 import { defSolo } from './defSolo.js'
 
@@ -7,7 +7,6 @@ import { defSolo } from './defSolo.js'
 // injects results to the base module via self
 export function buildSoloDefs(self) {
 	// var c, i, ch, cm, cMap, id, actID, soloID, cmd, pfx
-
 	let stat = {}
 	let soloFbToStat = {}
 	let soloActions = {}
@@ -187,6 +186,13 @@ export function buildSoloDefs(self) {
 									min: -100,
 									max: 100,
 									default: 1,
+								},
+								{
+									type: 'checkbox',
+									tooltip: 'If the adjustment were to set the fader above 0.0dB, it will rather aim for 0.0dB',
+									label: 'Limit fader to 0.0dB maximum',
+									id: 'faderLim',
+									default: 0,
 								},
 							],
 							callback: async (action, context) => {

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -726,6 +726,13 @@ export function buildStripDefs(self) {
 							max: 100,
 							default: 1,
 						},
+						{
+							type: 'checkbox',
+							tooltip: 'If the adjustment were to set the fader above 0.0dB, it will rather aim for 0.0dB',
+							label: 'Limit fader to 0.0dB maximum',
+							id: 'faderLim',
+							default: 0,
+						}
 					],
 					callback: async (action, context) => {
 						const opt = action.options

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -535,6 +535,14 @@ export function buildStripDefs(self) {
 					default: 1,
 				})
 
+				fadeActions[fadeID + '_a'].options.push({
+					type: 'checkbox',
+					tooltip: 'Limit fader adjustment to 0dBfs maximum, if the adjustment were to go above 0dB, it will go back to 0dB',
+					label: 'Limit to 0dB maximum',
+					id: 'faderLim',
+					default: 0,
+				})
+
 				for (var sfx of ['', '_a']) {
 					fadeActions[fadeID + sfx].options.push({
 						type: 'number',

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -537,7 +537,7 @@ export function buildStripDefs(self) {
 
 				fadeActions[fadeID + '_a'].options.push({
 					type: 'checkbox',
-					tooltip: 'Limit fader adjustment to 0dBfs maximum, if the adjustment were to go above 0dB, it will go back to 0dB',
+					tooltip: 'Limit the fader to 0.0dB max:\nIf the adjustment were to set it above 0.0dB, it will rather aim for 0.0dB.',
 					label: 'Limit to 0dB maximum',
 					id: 'faderLim',
 					default: 0,

--- a/buildStripDefs.js
+++ b/buildStripDefs.js
@@ -537,8 +537,8 @@ export function buildStripDefs(self) {
 
 				fadeActions[fadeID + '_a'].options.push({
 					type: 'checkbox',
-					tooltip: 'Limit the fader to 0.0dB max:\nIf the adjustment were to set it above 0.0dB, it will rather aim for 0.0dB.',
-					label: 'Limit to 0dB maximum',
+					tooltip: 'If the adjustment were to set the fader above 0.0dB, it will rather aim for 0.0dB',
+					label: 'Limit fader to 0.0dB maximum',
 					id: 'faderLim',
 					default: 0,
 				})

--- a/helpers.js
+++ b/helpers.js
@@ -37,7 +37,7 @@ export function fadeTo(cmd, strip, opt, self) {
 			// byVal = (opTicks * steps) / 100
 			// newIdx = Math.min(steps - 1, Math.max(0, oldIdx + Math.round(byVal)))
 			r = self.fLevels[steps][newIdx]
-			// If fader is at more than 0dB  revert to 0dB, dependant on the "Limit faders to 0dB Max" checkbox in the button settings
+			// If fader is at more than 0dB, revert to 0dB, dependant on the "Limit faders to 0dB Max" checkbox in the button settings
 			if (faderLim) r = Math.min(r, 0.75)
 			break
 		case '_r': // restore
@@ -71,7 +71,7 @@ export function fadeTo(cmd, strip, opt, self) {
 		}
 	}
 
-	self.log('info', `---------- ${oldIdx} , ${newIdx}, ${byVal}, ${r}----------`);
+	// self.log('debug',`---------- ${oldIdx}:${oldVal} by ${byVal}(${opTicks}) fadeTo ${newIdx}:${r} ----------`);
 
 	return r
 }

--- a/helpers.js
+++ b/helpers.js
@@ -70,7 +70,7 @@ export function fadeTo(cmd, strip, opt, self) {
 	}
 
 	// If fader is at more than 0dB, or 0,75f, revert to 0,75, dependant on the "Limit faders to 0dB Max" checkbox in the module settings
-	/* if (faderLim) r = Math.min(r, 0.75); */
+	if (faderLim) r = Math.min(r, 0.75);
 
 	// self.log('debug',`---------- ${oldIdx}:${oldVal} by ${byVal}(${opTicks}) fadeTo ${newIdx}:${r} ----------`);
 

--- a/helpers.js
+++ b/helpers.js
@@ -37,6 +37,8 @@ export function fadeTo(cmd, strip, opt, self) {
 			// byVal = (opTicks * steps) / 100
 			// newIdx = Math.min(steps - 1, Math.max(0, oldIdx + Math.round(byVal)))
 			r = self.fLevels[steps][newIdx]
+			// If fader is at more than 0dB  revert to 0dB, dependant on the "Limit faders to 0dB Max" checkbox in the button settings
+			if (faderLim) r = Math.min(r, 0.75)
 			break
 		case '_r': // restore
 			r = slot && self.tempStore[slot] ? self.tempStore[slot] : -1
@@ -69,10 +71,7 @@ export function fadeTo(cmd, strip, opt, self) {
 		}
 	}
 
-	// If fader is at more than 0dB, or 0,75f, revert to 0,75, dependant on the "Limit faders to 0dB Max" checkbox in the module settings
-	if (faderLim) r = Math.min(r, 0.75);
-
-	// self.log('debug',`---------- ${oldIdx}:${oldVal} by ${byVal}(${opTicks}) fadeTo ${newIdx}:${r} ----------`);
+	self.log('info', `---------- ${oldIdx} , ${newIdx}, ${byVal}, ${r}----------`);
 
 	return r
 }

--- a/helpers.js
+++ b/helpers.js
@@ -22,6 +22,7 @@ export function fadeTo(cmd, strip, opt, self) {
 
 
 	const opTicks = parseInt(opt.ticks)
+	const faderLim = opt.faderLim
 	const steps = stat.fSteps
 	const span = parseFloat(opt.duration)
 	const oldVal = stat[node]
@@ -67,6 +68,11 @@ export function fadeTo(cmd, strip, opt, self) {
 			r = oldVal + xDelta
 		}
 	}
+
+	// If fader is at more than 0dB, or 0,75f, revert to 0,75, dependant on the "Limit faders to 0dB Max" checkbox in the module settings
+	/* if (faderLim) r = Math.min(r, 0.75); */
+
 	// self.log('debug',`---------- ${oldIdx}:${oldVal} by ${byVal}(${opTicks}) fadeTo ${newIdx}:${r} ----------`);
+
 	return r
 }

--- a/helpers.js
+++ b/helpers.js
@@ -37,8 +37,8 @@ export function fadeTo(cmd, strip, opt, self) {
 			// byVal = (opTicks * steps) / 100
 			// newIdx = Math.min(steps - 1, Math.max(0, oldIdx + Math.round(byVal)))
 			r = self.fLevels[steps][newIdx]
-			// If fader is at more than 0dB, revert to 0dB, dependant on the "Limit faders to 0dB Max" checkbox in the button settings
-			if (faderLim) r = Math.min(r, 0.75)
+			// When "Limit faders to 0dB Max" is checked, If fader was going to be >0dB, aim at 0dB (also, -0.3dB will and above snap to 0.0dB)
+			faderLim && r >= 0.74 ? r = 0.75 : r;
 			break
 		case '_r': // restore
 			r = slot && self.tempStore[slot] ? self.tempStore[slot] : -1


### PR DESCRIPTION
Previous PR closed as I renamed the branch.... sorry!

As asked in [this issue](https://github.com/bitfocus/companion-module-behringer-xair/issues/71), I tried to implement a 0dB limit for the faders, and instead of a global setting, I chose to make it per button, which I think is smarter and less messy code wise

Here's the first commit
- Adding a "Limit to 0dB maximum" checkbox in the fader adjust button settings
- Grabbing the bool value of said checkbox (faderLim) to condition a limit to 0.75f on the fader (0dB)

I placed the condition at the very end of the FadeTo function, this might have some unintended effect on the fading, or maybe not and it was the right wall, haven't tested yet