### PR TITLE
Change method to retrieve broadcast addresses and update probe to use…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "behringer-xair",
-	"version": "2.6.3",
+	"version": "2.6.4",
 	"type": "module",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Attempting to fix https://github.com/bitfocus/companion-module-behringer-xair/issues/126

Haven't tested in-app but the getBroadcastAddress works on its own in node